### PR TITLE
Fix possible segfault

### DIFF
--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -387,6 +387,10 @@ func (c *MonitoringCollector) reportTimeSeriesMetrics(
 			metricValue = *newestTSPoint.Value.DoubleValue
 		case "DISTRIBUTION":
 			dist := newestTSPoint.Value.DistributionValue
+			if dist == nil {
+				level.Debug(c.logger).Log("msg", "discarding", "resource", timeSeries.Resource.Type, "metric", timeSeries.Metric.Type, "err", "Point without distribution value")
+				continue
+			}
 			buckets, err := c.generateHistogramBuckets(dist)
 			if err == nil {
 				timeSeriesMetrics.CollectNewConstHistogram(timeSeries, newestEndTime, labelKeys, dist, buckets, labelValues)


### PR DESCRIPTION
[Point.Value](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue) may contain one of the values, but not necessarily. This attempts to avoid uninitialized access of the DistributionValue` property.

Also adds checking for execution errors when fetching the time series.
